### PR TITLE
feat: add coder-workspace image

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Each package is available as `latest` tag and tags specifying the version.
 
 > **Note:** The `test` package is a package for testing purposes without any application.=
 
-| Package                                                                               | Image                            |
-| ------------------------------------------------------------------------------------- | -------------------------------- |
-| [minio-bucket](https://github.com/davidborzek/containers/pkgs/container/minio-bucket) | ghcr.io/davidborzek/minio-bucket |
+| Package                                                                                     | Image                               |
+| ------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [coder-workspace](https://github.com/davidborzek/containers/pkgs/container/coder-workspace) | ghcr.io/davidborzek/coder-workspace |
+| [minio-bucket](https://github.com/davidborzek/containers/pkgs/container/minio-bucket)       | ghcr.io/davidborzek/minio-bucket    |
 | [mylar3](https://github.com/davidborzek/containers/pkgs/container/mylar3)             | ghcr.io/davidborzek/mylar3       |
 | [tautulli](https://github.com/davidborzek/containers/pkgs/container/tautulli)         | ghcr.io/davidborzek/tautulli     |
 

--- a/packages/coder-workspace/Dockerfile
+++ b/packages/coder-workspace/Dockerfile
@@ -1,0 +1,78 @@
+FROM debian:12-slim
+
+ARG VERSION
+
+# renovate: datasource=github-releases depName=coder/code-server
+ARG CODE_SERVER_VERSION=4.130.0
+# renovate: datasource=github-releases depName=cli/cli
+ARG GH_VERSION=2.63.2
+# renovate: datasource=github-releases depName=anomalyco/opencode
+ARG OPENCODE_VERSION=1.18.12
+# pinned nix-direnv direnvrc (provides `use flake`)
+ARG NIX_DIRENV_VERSION=3.0.6
+
+ENV LANG=C.UTF-8 \
+    SHELL=/bin/bash \
+    NIX_REMOTE="" \
+    DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl wget jq unzip xz-utils \
+        bash sudo procps \
+        git git-lfs openssh-client \
+        tmux direnv \
+    && rm -rf /var/lib/apt/lists/*
+
+# nix flakes config (honoured by the single-user store too)
+RUN mkdir -p /etc/nix \
+    && printf 'experimental-features = nix-command flakes\naccept-flake-config = true\n' > /etc/nix/nix.conf
+
+# gh cli
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+      | tar -xz -C /tmp \
+    && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
+    && rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64"
+
+# code-server (standalone, glibc)
+RUN curl -fsSL https://code-server.dev/install.sh \
+      | sh -s -- --method=standalone --prefix=/usr/local --version="${CODE_SERVER_VERSION}"
+
+# opencode (installer reads $VERSION as the opencode version to fetch; pin it)
+RUN curl -fsSL https://opencode.ai/install | env VERSION="${OPENCODE_VERSION}" bash \
+    && install -m 0755 /root/.opencode/bin/opencode /usr/local/bin/opencode \
+    && rm -rf /root/.opencode
+
+# non-root user "coder" (uid 1000), owns the nix store (single-user)
+RUN useradd -m -u 1000 -s /bin/bash coder \
+    && echo 'coder ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/coder \
+    && mkdir -m 0755 /nix \
+    && chown coder:coder /nix
+
+USER coder
+ENV USER=coder \
+    HOME=/home/coder
+WORKDIR /home/coder
+
+# nix (recent, single-user) + direnv/nix-direnv (auto-enter devShells via `use flake`)
+RUN curl -fsSL https://nixos.org/nix/install | sh -s -- --no-daemon \
+    && mkdir -p ~/.config/direnv \
+    && curl -fsSL "https://raw.githubusercontent.com/nix-community/nix-direnv/${NIX_DIRENV_VERSION}/direnvrc" \
+         -o ~/.config/direnv/direnvrc \
+    && printf '%s\n' \
+         '' \
+         '# nix single-user + local tools on PATH' \
+         '[ -f ~/.nix-profile/etc/profile.d/nix.sh ] && . ~/.nix-profile/etc/profile.d/nix.sh' \
+         'export PATH="/usr/local/bin:$PATH"' \
+         'eval "$(direnv hook bash)"' \
+         >> ~/.bashrc \
+    && printf '%s\n' '[ -f ~/.bashrc ] && . ~/.bashrc' > ~/.bash_profile
+
+# make nix + local tools available in non-interactive shells too (Debian's
+# .bashrc returns early when non-interactive, so PATH must be set here as well)
+ENV PATH="/home/coder/.nix-profile/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    NIX_SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+
+LABEL org.opencontainers.image.source="https://github.com/davidborzek/containers"

--- a/packages/coder-workspace/README.md
+++ b/packages/coder-workspace/README.md
@@ -1,0 +1,18 @@
+# coder-workspace
+
+A lean Alpine base image for [Coder](https://coder.com) workspaces focused on an
+AI coding-agent workflow.
+
+Ships (all on `PATH` in `/usr/local/bin` or via apk):
+
+- `opencode` — the coding agent (point it at a model via `OPENCODE_API_KEY`)
+- `code-server` — VS Code in the browser
+- `tmux` — keep the agent session alive across SSH disconnects
+- `git`, `git-lfs`, `gh`, `openssh-client`
+- `nix` (flakes, single-user) + `direnv`/`nix-direnv` — enter per-project
+  devShells with `nix develop` or automatically via a `.envrc` (`use flake`)
+
+Runs as the non-root user `coder` (uid 1000), which owns the Nix store.
+
+> Language toolchains are intentionally **not** baked in. Provide them
+> per-project through a `flake.nix` devShell instead of bloating the image.

--- a/packages/coder-workspace/goss.yaml
+++ b/packages/coder-workspace/goss.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
+command:
+  command -v git:
+    exit-status: 0
+  command -v gh:
+    exit-status: 0
+  command -v tmux:
+    exit-status: 0
+  command -v opencode:
+    exit-status: 0
+  command -v code-server:
+    exit-status: 0
+  command -v nix:
+    exit-status: 0
+  command -v direnv:
+    exit-status: 0

--- a/packages/coder-workspace/package.yaml
+++ b/packages/coder-workspace/package.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/davidborzek/containers/main/package.schema.json
+---
+name: coder-workspace
+semver: true
+platforms: ["linux/amd64"]
+goss:
+  entrypoint: bash
+  args: -c "tail -f /dev/null"

--- a/packages/coder-workspace/version.sh
+++ b/packages/coder-workspace/version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+printf "%s" "0.1.0"


### PR DESCRIPTION
## What

Adds a **coder-workspace** base image for Coder workspaces geared toward an AI coding-agent workflow.

Ships (all on `PATH`):
- **opencode** `1.18.12` — the coding agent
- **code-server** `4.130.0` — VS Code in the browser
- **tmux** — keep the agent session alive across SSH disconnects
- **git**, **git-lfs**, **gh**, **openssh-client**
- **Nix** (recent, flakes, single-user) + **direnv** / **nix-direnv** — projects bring their own toolchains via `flake.nix` devShells (`nix develop` or auto via `.envrc`)

Runs as the non-root user `coder` (uid 1000), which owns the Nix store.

## Base image

Uses **debian:12-slim (glibc)** instead of Alpine. code-server's bundled node fails on musl (`fcntl64: symbol not found` even with gcompat), and the npm/musl route doesn't build cleanly. Everything else was verified on Alpine, but code-server forces glibc.

## Validated locally

- `code-server --version` runs (glibc) ✓
- `opencode --version` → 1.18.12 ✓
- `nix shell nixpkgs#hello` → `Hello, world!` (single-user, non-interactive) ✓
- direnv hook + nix on PATH in interactive shells ✓

Language runtimes are intentionally **not** baked in — provide them per-project through a flake devShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
